### PR TITLE
Fix gethiddenproperty always being set to nil

### DIFF
--- a/saveinstance.luau
+++ b/saveinstance.luau
@@ -1958,7 +1958,7 @@ local function synsaveinstance(CustomOptions, CustomOptions2)
 	local IgnorePropertiesOfNotScriptsOnScriptsMode = OPTIONS.IgnorePropertiesOfNotScriptsOnScriptsMode
 
 	local old_gethiddenproperty
-	if OPTIONS and gethiddenproperty then
+	if OPTIONS.IgnoreSpecialProperties and gethiddenproperty then
 		old_gethiddenproperty = gethiddenproperty
 		gethiddenproperty = nil
 	end


### PR DESCRIPTION
Fix gethiddenproperty always being set to nil, that was breaking save for MeshParts even on executors that support it